### PR TITLE
Feature/segmented progress view

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Home()
     }
 }
 

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,0 +1,18 @@
+//
+//  ContentView.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Model/Home.swift
+++ b/Model/Home.swift
@@ -1,0 +1,14 @@
+//
+//  Home.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+
+struct Home: View {
+    var body: some View {
+        IntermediateView()
+    }
+}

--- a/View-Model/CarouselView.swift
+++ b/View-Model/CarouselView.swift
@@ -39,17 +39,20 @@ struct CarouselView: View {
     }
 
     private func handleTap(location: CGPoint) {
-        let screenWidth = UIScreen.main.bounds.width
-        let midX = screenWidth / 2
-        if location.x > midX {
-            storyController.handleRightTap(imagesCount: imagesNames.count)
-        } else {
-            storyController.handleLeftTap()
-        }
-
-        
-        if Int(storyController.progress) == imagesNames.count - 1 {
-            isPresented = false
+            let screenWidth = UIScreen.main.bounds.width
+            let midX = screenWidth / 2
+            
+            if location.x > midX {
+                
+                if Int(storyController.progress) < imagesNames.count - 1 {
+                    storyController.handleRightTap(imagesCount: imagesNames.count)
+                } else if Int(storyController.progress) == imagesNames.count - 1 {
+                    
+                    isPresented = false
+                }
+            } else {
+                
+                storyController.handleLeftTap()
+            }
         }
     }
-}

--- a/View-Model/CarouselView.swift
+++ b/View-Model/CarouselView.swift
@@ -1,0 +1,55 @@
+//
+//  CarouselView.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+
+struct CarouselView: View {
+    var imagesNames: [String]
+    @Binding var isPresented: Bool
+    @StateObject private var storyController: StoryController
+
+    init(imagesNames: [String], isPresented: Binding<Bool>) {
+        _storyController = StateObject(wrappedValue: StoryController(items: imagesNames.count, interval: 3.0))
+        self.imagesNames = imagesNames
+        self._isPresented = isPresented
+    }
+
+    var body: some View {
+        VStack {
+            StoryProgressView(imagesNames: imagesNames, progress: $storyController.progress)
+                .gesture(
+                    DragGesture()
+                        .onEnded { gesture in
+                            if gesture.translation.height > 100 {
+                                isPresented = false
+                            }
+                        }
+                )
+        }
+        .onAppear {
+            storyController.storyTimer.start()
+        }
+        .onTapGesture { location in
+            handleTap(location: location)
+        }
+    }
+
+    private func handleTap(location: CGPoint) {
+        let screenWidth = UIScreen.main.bounds.width
+        let midX = screenWidth / 2
+        if location.x > midX {
+            storyController.handleRightTap(imagesCount: imagesNames.count)
+        } else {
+            storyController.handleLeftTap()
+        }
+
+        
+        if Int(storyController.progress) == imagesNames.count - 1 {
+            isPresented = false
+        }
+    }
+}

--- a/View-Model/IntermediateView.swift
+++ b/View-Model/IntermediateView.swift
@@ -1,0 +1,43 @@
+//
+//  IntermediateView.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+
+struct IntermediateView: View {
+    @State private var showCarousel = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(gradient: Gradient(colors: [Color.black, Color.gray]), startPoint: .top, endPoint: .bottom)
+                           .ignoresSafeArea()
+            HStack {
+                Button(action: {
+                    showCarousel = true
+                }) {
+                    Text("Open Carousel")
+                        .font(.title)
+                        .padding()
+                        .background(
+                            LinearGradient(
+                                gradient: Gradient(colors: [Color.black, Color.gray]),
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+            }
+        }
+        .fullScreenCover(isPresented: $showCarousel) {
+            CarouselView(imagesNames: ["butcher", "hughei", "frenchie", "mm"], isPresented: $showCarousel)
+                .transition(.move(edge: .bottom)) // Bottom-up animation
+                .ignoresSafeArea() // Ensures the view covers the entire screen
+        }
+    }
+}
+

--- a/View-Model/IntermediateView.swift
+++ b/View-Model/IntermediateView.swift
@@ -20,24 +20,22 @@ struct IntermediateView: View {
                 }) {
                     Text("Open Carousel")
                         .font(.title)
-                        .padding()
-                        .background(
-                            LinearGradient(
-                                gradient: Gradient(colors: [Color.black, Color.gray]),
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
                         .foregroundColor(.white)
-                        .cornerRadius(10)
+                        .padding()
+                        .background(Color.black)
+                        .cornerRadius(20)
+                }
+            
+                        
                 }
             }
-        }
         .fullScreenCover(isPresented: $showCarousel) {
             CarouselView(imagesNames: ["butcher", "hughei", "frenchie", "mm"], isPresented: $showCarousel)
-                .transition(.move(edge: .bottom)) // Bottom-up animation
-                .ignoresSafeArea() // Ensures the view covers the entire screen
+                .transition(.move(edge: .bottom))
+                .ignoresSafeArea()
         }
+        }
+        
     }
-}
+
 

--- a/View-Model/StoryController.swift
+++ b/View-Model/StoryController.swift
@@ -1,0 +1,38 @@
+//
+//  StoryController.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+import Combine
+
+class StoryController: ObservableObject {
+    @Published var progress: Double = 0
+    public let storyTimer: StoryTimer
+
+    init(items: Int, interval: TimeInterval) {
+        self.storyTimer = StoryTimer(items: items, interval: interval)
+        self.storyTimer.$progress
+            .assign(to: &$progress)
+    }
+
+    func handleLeftTap() {
+        if Int(progress) > 0 {
+            resetProgress(for: Int(progress) - 1)
+        }
+    }
+
+    func handleRightTap(imagesCount: Int) {
+        if Int(progress) < imagesCount - 1 {
+            resetProgress(for: Int(progress) + 1)
+        }
+    }
+
+    private func resetProgress(for index: Int) {
+        withAnimation {
+            storyTimer.resetProgressForNextImage(startAt: index)
+        }
+    }
+}

--- a/View-Model/StoryTimer.swift
+++ b/View-Model/StoryTimer.swift
@@ -1,0 +1,43 @@
+//
+//  StoryTimer.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+import Foundation
+import Combine
+
+class StoryTimer: ObservableObject {
+    @Published var progress: Double = 0
+    private var interval: TimeInterval
+    private var max: Int
+    private var cancellable: Cancellable?
+    private let publisher: Timer.TimerPublisher
+
+    init(items: Int, interval: TimeInterval) {
+        self.max = items
+        self.interval = interval
+        self.publisher = Timer.publish(every: 0.1, on: .main, in: .default)
+    }
+
+    func start() {
+        self.cancellable = self.publisher.autoconnect().sink { _ in
+            var newProgress = self.progress + (0.1 / self.interval)
+            if newProgress >= Double(self.max) {
+                newProgress = 0
+            }
+            self.progress = newProgress
+        }
+    }
+
+    func resetProgressForNextImage(startAt index: Int) {
+        self.progress = Double(index)
+    }
+
+    func stop() {
+        self.cancellable?.cancel()
+    }
+}
+

--- a/View/LoadingRectangle.swift
+++ b/View/LoadingRectangle.swift
@@ -1,0 +1,26 @@
+//
+//  LoadingRectangle.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+
+struct LoadingRectangle: View {
+    var progress: CGFloat
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .foregroundStyle(Color.white.opacity(0.3))
+                    .cornerRadius(5)
+                Rectangle()
+                    .frame(width: geometry.size.width * self.progress)
+                    .foregroundStyle(Color.white.opacity(1.0))
+                    .cornerRadius(5)
+            }
+        }
+    }
+}

--- a/View/StoryProgressView.swift
+++ b/View/StoryProgressView.swift
@@ -1,0 +1,38 @@
+//
+//  StoryProgressView.swift
+//  Vought Showcase
+//
+//  Created by Mehul Jain on 27/08/24.
+//
+
+import SwiftUI
+
+struct StoryProgressView: View {
+    var imagesNames: [String]
+    @Binding var progress: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .top) {
+                Image(imagesNames[Int(progress)])
+                    .resizable()
+                    .ignoresSafeArea(edges: .all)
+                    .scaledToFill()
+                    .frame(width: geometry.size.width, height: geometry.size.height, alignment: .center)
+                    .contentShape(Rectangle())
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.5), value: progress)
+                
+                HStack(alignment: .center, spacing: 4) {
+                    ForEach(imagesNames.indices, id: \.self) { index in
+                        LoadingRectangle(progress: min(max(CGFloat(progress) - CGFloat(index), 0.0), 1.0))
+                            .frame(height: 3.5)
+                            .animation(.linear, value: progress)
+                    }
+                }
+                .padding(.vertical, 60)
+            }
+        }
+    }
+}
+

--- a/Vought Showcase.xcodeproj/project.pbxproj
+++ b/Vought Showcase.xcodeproj/project.pbxproj
@@ -28,6 +28,14 @@
 		5E87DC912C6232440005D86C /* Vought_ShowcaseUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E87DC902C6232440005D86C /* Vought_ShowcaseUITestsLaunchTests.swift */; };
 		5E87DCA02C6236A30005D86C /* CarouselViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E87DC9F2C6236A30005D86C /* CarouselViewController.swift */; };
 		5E87DCA22C62375E0005D86C /* CarouselViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5E87DCA12C62375E0005D86C /* CarouselViewController.xib */; };
+		750B8A3A2C7E299E005B8304 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A392C7E299E005B8304 /* ContentView.swift */; };
+		750B8A3C2C7E29B5005B8304 /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A3B2C7E29B5005B8304 /* Home.swift */; };
+		750B8A3E2C7E29C3005B8304 /* LoadingRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A3D2C7E29C3005B8304 /* LoadingRectangle.swift */; };
+		750B8A402C7E29D4005B8304 /* StoryProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A3F2C7E29D4005B8304 /* StoryProgressView.swift */; };
+		750B8A422C7E29E2005B8304 /* StoryTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A412C7E29E2005B8304 /* StoryTimer.swift */; };
+		750B8A442C7E29EC005B8304 /* StoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A432C7E29EC005B8304 /* StoryController.swift */; };
+		750B8A462C7E29FB005B8304 /* IntermediateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A452C7E29FB005B8304 /* IntermediateView.swift */; };
+		750B8A482C7E2A07005B8304 /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B8A472C7E2A07005B8304 /* CarouselView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +81,14 @@
 		5E87DC902C6232440005D86C /* Vought_ShowcaseUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vought_ShowcaseUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		5E87DC9F2C6236A30005D86C /* CarouselViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselViewController.swift; sourceTree = "<group>"; };
 		5E87DCA12C62375E0005D86C /* CarouselViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CarouselViewController.xib; sourceTree = "<group>"; };
+		750B8A392C7E299E005B8304 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		750B8A3B2C7E29B5005B8304 /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
+		750B8A3D2C7E29C3005B8304 /* LoadingRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingRectangle.swift; sourceTree = "<group>"; };
+		750B8A3F2C7E29D4005B8304 /* StoryProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryProgressView.swift; sourceTree = "<group>"; };
+		750B8A412C7E29E2005B8304 /* StoryTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryTimer.swift; sourceTree = "<group>"; };
+		750B8A432C7E29EC005B8304 /* StoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryController.swift; sourceTree = "<group>"; };
+		750B8A452C7E29FB005B8304 /* IntermediateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntermediateView.swift; sourceTree = "<group>"; };
+		750B8A472C7E2A07005B8304 /* CarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +173,10 @@
 		5E87DC612C6232430005D86C = {
 			isa = PBXGroup;
 			children = (
+				750B8A392C7E299E005B8304 /* ContentView.swift */,
+				750B8A492C7E2A94005B8304 /* Model */,
+				750B8A4A2C7E2A9C005B8304 /* View */,
+				750B8A4B2C7E2AA2005B8304 /* View-Model */,
 				5E87DC6C2C6232430005D86C /* Vought Showcase */,
 				5E87DC832C6232440005D86C /* Vought ShowcaseTests */,
 				5E87DC8D2C6232440005D86C /* Vought ShowcaseUITests */,
@@ -217,6 +237,34 @@
 				5E1E353E2C6247C5000D7DEF /* ImageViewController.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		750B8A492C7E2A94005B8304 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				750B8A3B2C7E29B5005B8304 /* Home.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		750B8A4A2C7E2A9C005B8304 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				750B8A3D2C7E29C3005B8304 /* LoadingRectangle.swift */,
+				750B8A3F2C7E29D4005B8304 /* StoryProgressView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		750B8A4B2C7E2AA2005B8304 /* View-Model */ = {
+			isa = PBXGroup;
+			children = (
+				750B8A412C7E29E2005B8304 /* StoryTimer.swift */,
+				750B8A432C7E29EC005B8304 /* StoryController.swift */,
+				750B8A472C7E2A07005B8304 /* CarouselView.swift */,
+				750B8A452C7E29FB005B8304 /* IntermediateView.swift */,
+			);
+			path = "View-Model";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -351,19 +399,27 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				750B8A3E2C7E29C3005B8304 /* LoadingRectangle.swift in Sources */,
 				5E1E35442C62497D000D7DEF /* HomeLanderCarouselItem.swift in Sources */,
+				750B8A482C7E2A07005B8304 /* CarouselView.swift in Sources */,
+				750B8A422C7E29E2005B8304 /* StoryTimer.swift in Sources */,
 				5E87DCA02C6236A30005D86C /* CarouselViewController.swift in Sources */,
 				5E87DC722C6232430005D86C /* MainViewController.swift in Sources */,
 				5E1E35482C624B31000D7DEF /* BlackNoirCarouselItem.swift in Sources */,
 				5E1E354A2C624BAB000D7DEF /* ATrainCarouselItem.swift in Sources */,
 				5E87DC6E2C6232430005D86C /* AppDelegate.swift in Sources */,
+				750B8A402C7E29D4005B8304 /* StoryProgressView.swift in Sources */,
 				5E1E35462C624AB9000D7DEF /* MaeveCarouselItem.swift in Sources */,
 				5E1E354F2C624C2A000D7DEF /* CarouselItemDataSourceProviderType.swift in Sources */,
+				750B8A462C7E29FB005B8304 /* IntermediateView.swift in Sources */,
 				5E1E353D2C623996000D7DEF /* UIViewController+AddChild.swift in Sources */,
 				5E1E35512C624C4D000D7DEF /* CarouselItemDataSourceProvider.swift in Sources */,
 				5E1E35422C6248A6000D7DEF /* CarouselItem.swift in Sources */,
+				750B8A3A2C7E299E005B8304 /* ContentView.swift in Sources */,
 				5E1E353F2C6247C5000D7DEF /* ImageViewController.swift in Sources */,
 				5E87DC702C6232430005D86C /* SceneDelegate.swift in Sources */,
+				750B8A442C7E29EC005B8304 /* StoryController.swift in Sources */,
+				750B8A3C2C7E29B5005B8304 /* Home.swift in Sources */,
 				5E1E35572C634D75000D7DEF /* SegmentedProgressBar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Vought Showcase/SceneDelegate.swift
+++ b/Vought Showcase/SceneDelegate.swift
@@ -6,17 +6,21 @@
 //
 
 import UIKit
+import SwiftUI
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        
+        let contentView = ContentView()
+        if let windowScene = scene as? UIWindowScene {
+            let window = UIWindow(windowScene: windowScene)
+            window.rootViewController = UIHostingController(rootView: contentView)
+            self.window = window
+            window.makeKeyAndVisible()
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -46,7 +50,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
 


### PR DESCRIPTION
CHANGES MADE 
1.Added the segmented progress bar to the UI
2.Replaced The Seven members with The Boys
3.Converted the UI to full-screen.
4.Removed the swipe gestures,thereby automatically showing the next member when a segment's progress is complete. 5.Implemented tapping on right/left corners to show next/previous members, ensuring the segmented progress bar updates accordingly.

BONUS Points:
1.Implemented using SwiftUI
2.Added an intermediate view controller with a button that opens the CarouselView with a bottom-up animation and closes the view controller when the user swipes down or all members have been shown.